### PR TITLE
Ignore .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ node_modules/
 
 # Optional npm cache directory
 .npm
+
+# Editor files
+.vscode/


### PR DESCRIPTION
Ignore `.vscode/` so it doesn't get included in the repository (holds VS Code specific files like `launch.json`).

Pull requests into js-ecqm-engine require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:** @okeefm
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass N/A

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
