### PR TITLE
Measure source

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,14 @@
 {
   "extends": "airbnb-base",
   "rules": {
-    "max-len": ["error", {"code": 100, "ignoreComments": true}]
+    "max-len": [
+      "error",
+      {
+        "code": 100,
+        "ignoreComments": true
+      }
+    ],
+    "prefer-destructuring": "off"
   },
   "env": {
     "jasmine": true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,17 @@
         "ignoreComments": true
       }
     ],
-    "prefer-destructuring": "off"
+    "prefer-destructuring": "off",
+    "comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "ignore"
+      }
+    ]
   },
   "env": {
     "jasmine": true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
 cache:
   directories:
     - "node_modules"
+services:
+  - mongodb
 script:
   - npm run lint
   - npm test

--- a/lib/models/measure_source.js
+++ b/lib/models/measure_source.js
@@ -1,0 +1,11 @@
+const _ = require('lodash');
+const MeasureSchema = require('cqm-models').MeasureSchema;
+const mongoose = require('mongoose');
+
+module.exports = class MongoDBMeasureSource {
+  constructor(connectionInfo) {
+    mongoose.connect(connectionInfo);
+
+    this.Measure = mongoose.model('Measure', MeasureSchema);
+  }
+};

--- a/lib/models/measure_source.js
+++ b/lib/models/measure_source.js
@@ -18,6 +18,7 @@ module.exports = class MongoDBMeasureSource {
   findMeasure(measureId, callback = null) {
     const self = this;
     let measureIdObj = null;
+    let err = null;
 
     if (typeof measureId === 'string') {
       measureIdObj = mongoose.Types.ObjectId(measureId);
@@ -25,18 +26,15 @@ module.exports = class MongoDBMeasureSource {
       measureIdObj = measureId;
     }
 
-    if (measureIdObj === null) return Error('measureId must be string or ObjectId');
+    if (measureIdObj === null) return TypeError('measureId must be string or ObjectId');
 
-    this.CQLMeasure.findById(measureIdObj, (err, measure) => {
-      if (err) return Error(err);
+    [err, this.measure] = this.CQLMeasure.findById(measureIdObj);
 
-      self.measure = measure;
+    if (err) return err;
 
-      if (callback != null) {
-        callback(self);
-      }
-      return null;
-    });
+    if (callback !== null) {
+      callback(self);
+    }
 
     return this.measure;
   }
@@ -51,17 +49,25 @@ module.exports = class MongoDBMeasureSource {
    */
   findMeasureByUser(userId, hqmfSetId, callback = null) {
     const self = this;
+    let err = null;
+    let userIdObj = null;
 
-    this.CQLMeasure.findOne({ user_id: userId, hqmf_set_id: hqmfSetId }, (err, measure) => {
-      if (err) return Error(err);
+    if (typeof userId === 'string') {
+      userIdObj = mongoose.Types.ObjectId(userId);
+    } else if (userId instanceof mongoose.Types.ObjectId) {
+      userIdObj = userId;
+    }
 
-      self.measure = measure;
+    if (userIdObj === null) return TypeError('userId must be string or ObjectId');
+    if (hqmfSetId === null) return TypeError('hqmfSetId must be string');
 
-      if (callback != null) {
-        callback(self);
-      }
-      return null;
-    });
+    [err, this.measure] = this.CQLMeasure.findOne({ user_id: userIdObj, hqmf_set_id: hqmfSetId });
+
+    if (err) return err;
+
+    if (callback !== null) {
+      callback(self);
+    }
 
     return this.measure;
   }

--- a/lib/models/measure_source.js
+++ b/lib/models/measure_source.js
@@ -15,10 +15,9 @@ module.exports = class MongoDBMeasureSource {
    * @param {function} callback - A function to run after searching for the measure
    * @returns {Measure | Error } - the Measure found, or an Error
    */
-  findMeasure(measureId, callback = null) {
+  async findMeasure(measureId, callback = null) {
     const self = this;
     let measureIdObj = null;
-    let err = null;
 
     if (typeof measureId === 'string') {
       measureIdObj = mongoose.Types.ObjectId(measureId);
@@ -28,15 +27,16 @@ module.exports = class MongoDBMeasureSource {
 
     if (measureIdObj === null) return TypeError('measureId must be string or ObjectId');
 
-    [err, this.measure] = this.CQLMeasure.findById(measureIdObj);
+    return this.CQLMeasure.findById(measureIdObj, (err, mes) => {
+      if (err) return err;
 
-    if (err) return err;
+      self.measure = mes;
 
-    if (callback !== null) {
-      callback(self);
-    }
-
-    return this.measure;
+      if (callback !== null) {
+        return callback(self);
+      }
+      return mes;
+    });
   }
 
   /**
@@ -47,9 +47,8 @@ module.exports = class MongoDBMeasureSource {
    * @param {function} callback - a function to be run after searching for the measure
    * @returns {Measure | Error } - the Measure found, or an Error
    */
-  findMeasureByUser(userId, hqmfSetId, callback = null) {
+  async findMeasureByUser(userId, hqmfSetId, callback = null) {
     const self = this;
-    let err = null;
     let userIdObj = null;
 
     if (typeof userId === 'string') {
@@ -61,14 +60,16 @@ module.exports = class MongoDBMeasureSource {
     if (userIdObj === null) return TypeError('userId must be string or ObjectId');
     if (hqmfSetId === null) return TypeError('hqmfSetId must be string');
 
-    [err, this.measure] = this.CQLMeasure.findOne({ user_id: userIdObj, hqmf_set_id: hqmfSetId });
+    return this.CQLMeasure.findOne({ user_id: userIdObj, hqmf_set_id: hqmfSetId }, (err, mes) => {
+      if (err) throw err;
 
-    if (err) return err;
+      self.measure = mes;
 
-    if (callback !== null) {
-      callback(self);
-    }
+      if (callback !== null) {
+        callback(self);
+      }
 
-    return this.measure;
+      return mes;
+    });
   }
 };

--- a/lib/models/measure_source.js
+++ b/lib/models/measure_source.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const MeasureSchema = require('cqm-models').MeasureSchema;
 const mongoose = require('mongoose');
 
@@ -6,6 +5,64 @@ module.exports = class MongoDBMeasureSource {
   constructor(connectionInfo) {
     mongoose.connect(connectionInfo);
 
-    this.Measure = mongoose.model('Measure', MeasureSchema);
+    this.CQLMeasure = mongoose.model('Measure', MeasureSchema);
+    this.measure = null;
+  }
+
+  /**
+   * This method searches for a measure given its ObjectId; if it finds it, it sets the measure property and runs callbacks, if any
+   * @param { string | mongoose.Types.ObjectId } measureId - The measure ObjectId (unique MongoDB identifier) to search by. If a string is passed in, it will be converted to an ObjectId
+   * @param {function} callback - A function to run after searching for the measure
+   * @returns {Measure | Error } - the Measure found, or an Error
+   */
+  findMeasure(measureId, callback = null) {
+    const self = this;
+    let measureIdObj = null;
+
+    if (typeof measureId === 'string') {
+      measureIdObj = mongoose.Types.ObjectId(measureId);
+    } else if (measureId instanceof mongoose.Types.ObjectId) {
+      measureIdObj = measureId;
+    }
+
+    if (measureIdObj === null) return Error('measureId must be string or ObjectId');
+
+    this.CQLMeasure.findById(measureIdObj, (err, measure) => {
+      if (err) return Error(err);
+
+      self.measure = measure;
+
+      if (callback != null) {
+        callback(self);
+      }
+      return null;
+    });
+
+    return this.measure;
+  }
+
+  /**
+   * This method searches for a measure given the user who owns it, and the hqmf set ID;
+   * if it finds it, it sets the measure property and runs callbacks, if any
+   * @param {string | mongoose.Types.ObjectId } userId - the user ObjectId (unique MongoDB identifier) to search by. If a string is passed in, it will be converted to an ObjectId
+   * @param {string} hqmfSetId - the HQMF set ID (measure-version neutral UUID, assigned by the MAT)
+   * @param {function} callback - a function to be run after searching for the measure
+   * @returns {Measure | Error } - the Measure found, or an Error
+   */
+  findMeasureByUser(userId, hqmfSetId, callback = null) {
+    const self = this;
+
+    this.CQLMeasure.findOne({ user_id: userId, hqmf_set_id: hqmfSetId }, (err, measure) => {
+      if (err) return Error(err);
+
+      self.measure = measure;
+
+      if (callback != null) {
+        callback(self);
+      }
+      return null;
+    });
+
+    return this.measure;
   }
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sinon": "^4"
   },
   "dependencies": {
-    "cqm-models": "projecttacoma/cqm-models#measure_model",
+    "cqm-models": "projecttacoma/cqm-models",
     "lodash": "^4.17.5",
     "mongoose": "^5.0.7"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "eslint": "^4.17.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0",
-    "jasmine": "^2.9.0"
+    "jasmine": "^2.9.0",
+    "sinon-mongoose": "^2.1.1",
+    "sinon": "^4"
   },
   "dependencies": {
     "cqm-models": "projecttacoma/cqm-models#measure_model",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-ecqm-engine",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -25,7 +25,7 @@
     "jasmine": "^2.9.0"
   },
   "dependencies": {
-    "cqm-models": "projecttacoma/cqm-models",
+    "cqm-models": "projecttacoma/cqm-models#measure_model",
     "lodash": "^4.17.5",
     "mongoose": "^5.0.7"
   }

--- a/spec/models/measure_source_spec.js
+++ b/spec/models/measure_source_spec.js
@@ -1,6 +1,8 @@
 const MeasureSource = require('../../lib/models/measure_source.js');
 const Measure = require('cqm-models').Measure;
 const Mongoose = require('mongoose');
+const Sinon = require('sinon');
+require('sinon-mongoose');
 
 describe('A MongoDB Measure Source', () => {
   const connectionInfo = 'mongodb://127.0.0.1:27017/js-ecqme-test';
@@ -8,67 +10,48 @@ describe('A MongoDB Measure Source', () => {
   const mes = new Measure({
     cms_id: 'CMS123',
   });
+  Sinon.mock(measureSource.CQLMeasure).expects('findOne').exactly(4).yields(null, mes);
 
   describe('Finding a measure given an ID', () => {
-    beforeEach(() => {
-      spyOn(measureSource.CQLMeasure, 'findById').and.returnValue([null, mes]);
-    });
-
     it('returns a measure given an ID (as a string)', () => {
-      expect(measureSource.findMeasure('56337c006c5d1c6930000417')).toBe(mes);
-      expect(measureSource.CQLMeasure.findById).toHaveBeenCalled();
+      Promise.resolve(measureSource.findMeasure('56337c006c5d1c6930000417'))
+        .then(response => expect(response).toBe(mes));
     });
 
     it('returns a measure given an ID (as an ObjectId)', () => {
-      expect(measureSource.findMeasure(Mongoose.Types.ObjectId('56337c006c5d1c6930000417')))
-        .toBe(mes);
-      expect(measureSource.CQLMeasure.findById).toHaveBeenCalled();
+      Promise.resolve(measureSource.findMeasure(Mongoose.Types.ObjectId('56337c006c5d1c6930000417')))
+        .then(response => expect(response).toBe(mes));
     });
 
     it('returns an error if you don\'t pass an ID', () => {
-      expect(measureSource.findMeasure(null).message)
-        .toEqual('measureId must be string or ObjectId');
-      expect(measureSource.CQLMeasure.findById).not.toHaveBeenCalled();
+      Promise.resolve(measureSource.findMeasure(null))
+        .then(response => expect(response.message).toEqual('measureId must be string or ObjectId'));
     });
   });
 
   describe('Finding a measure given a User ID and HQMF Set ID', () => {
-    beforeEach(() => {
-      spyOn(measureSource.CQLMeasure, 'findOne').and.callFake((query) => {
-        if (query.user_id instanceof Mongoose.Types.ObjectId &&
-          typeof query.hqmf_set_id === 'string') {
-          return [null, mes];
-        }
-        return TypeError('Incorrect Type Passed');
-      });
-    });
-
     it('returns a measure given a user ID (as a string) and an HQMF ID', () => {
-      expect(measureSource.findMeasureByUser(
+      Promise.resolve(measureSource.findMeasureByUser(
         '56337c006c5d1c6930000417',
         '1234-abcd-1234-abcd'
-      )).toBe(mes);
-      expect(measureSource.CQLMeasure.findOne).toHaveBeenCalled();
+      )).then(response => expect(response).toBe(mes));
     });
 
     it('returns a measure given a user ID (as an ObjectId) and an HQMF ID', () => {
-      expect(measureSource.findMeasureByUser(
+      Promise.resolve(measureSource.findMeasureByUser(
         Mongoose.Types.ObjectId('56337c006c5d1c6930000417'),
         '1234-abcd-1234-abcd'
-      )).toBe(mes);
-      expect(measureSource.CQLMeasure.findOne).toHaveBeenCalled();
+      )).then(response => expect(response).toBe(mes));
     });
 
     it('returns an error if you don\'t pass a user ID', () => {
-      expect(measureSource.findMeasureByUser(null, '1234-abcd-1234-abcd').message)
-        .toEqual('userId must be string or ObjectId');
-      expect(measureSource.CQLMeasure.findOne).not.toHaveBeenCalled();
+      Promise.resolve(measureSource.findMeasureByUser(null, '1234-abcd-1234-abcd'))
+        .then(response => expect(response.message).toEqual('userId must be string or ObjectId'));
     });
 
     it('returns an error if you don\'t pass an HQMF set ID', () => {
-      expect(measureSource.findMeasureByUser('56337c006c5d1c6930000417', null).message)
-        .toEqual('hqmfSetId must be string');
-      expect(measureSource.CQLMeasure.findOne).not.toHaveBeenCalled();
+      Promise.resolve(measureSource.findMeasureByUser('56337c006c5d1c6930000417', null))
+        .then(response => expect(response.message).toEqual('hqmfSetId must be string'));
     });
   });
 });

--- a/spec/models/measure_source_spec.js
+++ b/spec/models/measure_source_spec.js
@@ -1,5 +1,6 @@
 const MeasureSource = require('../../lib/models/measure_source.js');
 const Measure = require('cqm-models').Measure;
+const Mongoose = require('mongoose');
 
 describe('A MongoDB Measure Source', () => {
   const connectionInfo = 'mongodb://127.0.0.1:27017/js-ecqme-test';
@@ -8,12 +9,66 @@ describe('A MongoDB Measure Source', () => {
     cms_id: 'CMS123',
   });
 
-  beforeEach(() => {
-    spyOn(measureSource.CQLMeasure, 'findById').and.returnValue(null, mes);
+  describe('Finding a measure given an ID', () => {
+    beforeEach(() => {
+      spyOn(measureSource.CQLMeasure, 'findById').and.returnValue([null, mes]);
+    });
+
+    it('returns a measure given an ID (as a string)', () => {
+      expect(measureSource.findMeasure('56337c006c5d1c6930000417')).toBe(mes);
+      expect(measureSource.CQLMeasure.findById).toHaveBeenCalled();
+    });
+
+    it('returns a measure given an ID (as an ObjectId)', () => {
+      expect(measureSource.findMeasure(Mongoose.Types.ObjectId('56337c006c5d1c6930000417')))
+        .toBe(mes);
+      expect(measureSource.CQLMeasure.findById).toHaveBeenCalled();
+    });
+
+    it('returns an error if you don\'t pass an ID', () => {
+      expect(measureSource.findMeasure(null).message)
+        .toEqual('measureId must be string or ObjectId');
+      expect(measureSource.CQLMeasure.findById).not.toHaveBeenCalled();
+    });
   });
 
-  it('returns a measure given an ID (as a string)', () => {
-    expect(measureSource.findMeasure('56337c006c5d1c6930000417')).toBe(mes);
-    expect(measureSource.CQLMeasure.findById).toHaveBeenCalled();
+  describe('Finding a measure given a User ID and HQMF Set ID', () => {
+    beforeEach(() => {
+      spyOn(measureSource.CQLMeasure, 'findOne').and.callFake((query) => {
+        if (query.user_id instanceof Mongoose.Types.ObjectId &&
+          typeof query.hqmf_set_id === 'string') {
+          return [null, mes];
+        }
+        return TypeError('Incorrect Type Passed');
+      });
+    });
+
+    it('returns a measure given a user ID (as a string) and an HQMF ID', () => {
+      expect(measureSource.findMeasureByUser(
+        '56337c006c5d1c6930000417',
+        '1234-abcd-1234-abcd'
+      )).toBe(mes);
+      expect(measureSource.CQLMeasure.findOne).toHaveBeenCalled();
+    });
+
+    it('returns a measure given a user ID (as an ObjectId) and an HQMF ID', () => {
+      expect(measureSource.findMeasureByUser(
+        Mongoose.Types.ObjectId('56337c006c5d1c6930000417'),
+        '1234-abcd-1234-abcd'
+      )).toBe(mes);
+      expect(measureSource.CQLMeasure.findOne).toHaveBeenCalled();
+    });
+
+    it('returns an error if you don\'t pass a user ID', () => {
+      expect(measureSource.findMeasureByUser(null, '1234-abcd-1234-abcd').message)
+        .toEqual('userId must be string or ObjectId');
+      expect(measureSource.CQLMeasure.findOne).not.toHaveBeenCalled();
+    });
+
+    it('returns an error if you don\'t pass an HQMF set ID', () => {
+      expect(measureSource.findMeasureByUser('56337c006c5d1c6930000417', null).message)
+        .toEqual('hqmfSetId must be string');
+      expect(measureSource.CQLMeasure.findOne).not.toHaveBeenCalled();
+    });
   });
 });

--- a/spec/models/measure_source_spec.js
+++ b/spec/models/measure_source_spec.js
@@ -4,6 +4,8 @@ const Mongoose = require('mongoose');
 const Sinon = require('sinon');
 require('sinon-mongoose');
 
+const ObjectId = Mongoose.Types.ObjectId;
+
 describe('A MongoDB Measure Source', () => {
   const connectionInfo = 'mongodb://127.0.0.1:27017/js-ecqme-test';
   const measureSource = new MeasureSource(connectionInfo);
@@ -19,7 +21,7 @@ describe('A MongoDB Measure Source', () => {
     });
 
     it('returns a measure given an ID (as an ObjectId)', () => {
-      Promise.resolve(measureSource.findMeasure(Mongoose.Types.ObjectId('56337c006c5d1c6930000417')))
+      Promise.resolve(measureSource.findMeasure(ObjectId('56337c006c5d1c6930000417')))
         .then(response => expect(response).toBe(mes));
     });
 
@@ -39,7 +41,7 @@ describe('A MongoDB Measure Source', () => {
 
     it('returns a measure given a user ID (as an ObjectId) and an HQMF ID', () => {
       Promise.resolve(measureSource.findMeasureByUser(
-        Mongoose.Types.ObjectId('56337c006c5d1c6930000417'),
+        ObjectId('56337c006c5d1c6930000417'),
         '1234-abcd-1234-abcd'
       )).then(response => expect(response).toBe(mes));
     });

--- a/spec/models/measure_source_spec.js
+++ b/spec/models/measure_source_spec.js
@@ -1,0 +1,19 @@
+const MeasureSource = require('../../lib/models/measure_source.js');
+const Measure = require('cqm-models').Measure;
+
+describe('A MongoDB Measure Source', () => {
+  const connectionInfo = 'mongodb://127.0.0.1:27017/js-ecqme-test';
+  const measureSource = new MeasureSource(connectionInfo);
+  const mes = new Measure({
+    cms_id: 'CMS123',
+  });
+
+  beforeEach(() => {
+    spyOn(measureSource.CQLMeasure, 'findById').and.returnValue(null, mes);
+  });
+
+  it('returns a measure given an ID (as a string)', () => {
+    expect(measureSource.findMeasure('56337c006c5d1c6930000417')).toBe(mes);
+    expect(measureSource.CQLMeasure.findById).toHaveBeenCalled();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,9 +196,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cqm-models@projecttacoma/cqm-models:
-  version "0.0.1"
-  resolved "https://codeload.github.com/projecttacoma/cqm-models/tar.gz/f80bf552acc66ee20603fa058ec6bba54fea7470"
+cqm-models@projecttacoma/cqm-models#measure_model:
+  version "0.3.0"
+  resolved "https://codeload.github.com/projecttacoma/cqm-models/tar.gz/e50e20dafbf7dca77472017731a22372b75d2964"
   dependencies:
     mongoose "^5.0.7"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,9 +202,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cqm-models@projecttacoma/cqm-models#measure_model:
+cqm-models@projecttacoma/cqm-models:
   version "0.3.0"
-  resolved "https://codeload.github.com/projecttacoma/cqm-models/tar.gz/e50e20dafbf7dca77472017731a22372b75d2964"
+  resolved "https://codeload.github.com/projecttacoma/cqm-models/tar.gz/e5e68b76c2de0147efa82bf99fc05f5405eb8a07"
   dependencies:
     mongoose "^5.0.7"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@sinonjs/formatio@^2.0.0":
+  version "2.0.0"
+  resolved "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
+  dependencies:
+    samsam "1.3.0"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -237,6 +243,10 @@ del@^2.0.2:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
+
+diff@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -585,6 +595,10 @@ is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -624,6 +638,10 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
+just-extend@^1.1.27:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+
 kareem@2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.0.5.tgz#437e1e40f1be304ee21b3e4790eb3a05418b35ca"
@@ -651,13 +669,17 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash.get@4.4.2:
+lodash.get@4.4.2, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
 lodash@^4.14.0, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+lolex@^2.2.0, lolex@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.2.tgz#85f9450425103bf9e7a60668ea25dc43274ca807"
 
 lru-cache@^4.0.1:
   version "4.1.1"
@@ -744,6 +766,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+nise@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.3.2.tgz#fd6fd8dc040dfb3c0a45252feb6ff21832309b14"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    just-extend "^1.1.27"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
+
 normalize-package-data@^2.3.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
@@ -827,6 +859,12 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -966,6 +1004,10 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+samsam@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
+
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
@@ -983,6 +1025,22 @@ shebang-regex@^1.0.0:
 signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon-mongoose@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/sinon-mongoose/-/sinon-mongoose-2.1.1.tgz#197e7d187ae85e05eae97df895fffc1684277c93"
+
+sinon@^4:
+  version "4.4.9"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.4.9.tgz#0792a2a5171eb0cf242edacb0eba3898b8b4297f"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    diff "^3.1.0"
+    lodash.get "^4.4.2"
+    lolex "^2.2.0"
+    nise "^1.2.0"
+    supports-color "^5.1.0"
+    type-detect "^4.0.5"
 
 slice-ansi@1.0.0:
   version "1.0.0"
@@ -1061,6 +1119,12 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+supports-color@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  dependencies:
+    has-flag "^3.0.0"
+
 supports-color@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
@@ -1077,6 +1141,10 @@ table@^4.0.1:
     lodash "^4.17.4"
     slice-ansi "1.0.0"
     string-width "^2.1.1"
+
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 text-table@~0.2.0:
   version "0.2.0"
@@ -1097,6 +1165,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
This pull request provides a `MeasureSource` object that can pull measures out of MongoDB, either by `_id` (as a `string` or an `ObjectId`), or by `user_id` and `hqmf_set_id`. Also includes tests for the MeasureSource.

Pull requests into js-ecqm-engine require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

Merger: please **squash and merge**

**Submitter:** @okeefm
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/TACO-7
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @holmesie
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
