### PR TITLE
Fixed an issue in patient_source_spec 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,14 @@
         "exports": "always-multiline",
         "functions": "ignore"
       }
+    ],
+    "no-underscore-dangle": [
+      "error",
+      {
+        "allow": [
+          "_id"
+        ]
+      }
     ]
   },
   "env": {

--- a/spec/models/patient_source_spec.js
+++ b/spec/models/patient_source_spec.js
@@ -28,7 +28,7 @@ describe('A MongoDB Patient Source', () => {
     ];
 
     patientSource.reset();
-    const patientId1 = patientSource.nextPatient().id;
+    const patientId1 = patientSource.nextPatient()._id;
 
     let patient2 = patientSource.nextPatient();
     while (patient2 != null) {
@@ -36,15 +36,16 @@ describe('A MongoDB Patient Source', () => {
     }
 
     patientSource.reset();
-    const patientId2 = patientSource.nextPatient().id;
+    const patientId2 = patientSource.nextPatient()._id;
 
+    expect(patientId1, patientId2).toBeDefined();
     expect(patientId1).toBe(patientId2);
   });
 
   it('gets a list of MongoDB patients by one or more patient IDs', () => {
     const patientMongo = patientSource.QDMPatient({ given_names: ['A', 'B'], family_name: 'C' });
 
-    const patientId1 = patientMongo.id;
+    const patientId1 = patientMongo._id;
 
     patientMongo.save((err) => {
       if (err) return Error(err);


### PR DESCRIPTION
where we were comparing undefined to undefined, because we were calling `.id` rather than `._id`. Also updated `eslintrc.json` to allow us to call `._id` without eslint grumbling.

Pull requests into js-ecqm-engine require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @holmesie
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
