### PR TITLE
Added support for environment variables to the rabbit_worker

### DIFF
--- a/bin/rabbit_worker.js
+++ b/bin/rabbit_worker.js
@@ -4,16 +4,31 @@ const amqp = require('amqplib/callback_api');
 const Executor = require('../lib/executor');
 const mongoose = require('mongoose');
 
-amqp.connect('amqp://localhost', (err, conn) => {
+// Build the RabbitMQ connection URL, with sane defaults if the environment variables don't exist
+const rabbitHost = process.env.RABBITMQ_HOST ? process.env.RABBITMQ_HOST : 'localhost';
+const rabbitPort = process.env.RABBITMQ_PORT ? process.env.RABBITMQ_PORT : '5672';
+const rabbitURL = `amqp://${rabbitHost}:${rabbitPort}`;
+
+// Build the MongoDB connection URL, with sane defaults if the environment variables don't exist
+const mongoHost = process.env.MONGODB_HOST ? process.env.MONGODB_HOST : 'localhost';
+const mongoPort = process.env.MONGODB_HOST ? process.env.MONGODB_PORT : '27017';
+// use NODE_ENV to figure out what environment we're running in (or default to development)
+const cypressEnv = process.env.NODE_ENV ? process.env.NODE_ENV : 'development';
+// If we're running in a test environment, we'll need to get the env number to append to the DB
+// If we're not running in a test environment/this variable isn't set, this will be blank and won't matter
+const cypressTestNum = process.env.TEST_ENV_NUMBER ? process.env.TEST_ENV_NUMBER : '';
+const cypressDB = process.env.CYPRESS_DB ? process.env.CYPRESS_DB : `cypress_${cypressEnv}${cypressTestNum}`;
+const mongoURL = `mongodb://${mongoHost}:${mongoPort}/${cypressDB}`;
+
+amqp.connect(rabbitURL, (err, conn) => {
   conn.createChannel((chErr, ch) => {
     const q = 'calculation_queue';
 
     ch.assertQueue(q, { durable: true });
     ch.prefetch(1);
 
-    const connectionURL = 'mongodb://127.0.0.1:27017/cypress_development';
     const connectionOptions = { poolSize: 10 };
-    const connection = mongoose.createConnection(connectionURL, connectionOptions);
+    const connection = mongoose.createConnection(mongoURL, connectionOptions);
 
     process.on('close', conn.close);
 


### PR DESCRIPTION
This PR enables the `rabbit_worker` to get its configuration details from environment variables, including:

* RabbitMQ host (via `RABBITMQ_HOST`) (default `localhost`)
* RabbitMQ port (via `RABBITMQ_PORT`) (default `5672`)
* Cypress DB name (via `NODE_ENV` and `TEST_ENV_NUMBER`) (default `""`)
* MongoDB host (via `MONGODB_HOST`) (default `localhost`)
* MongoDB port (via `MONGODB_PORT`) (default `27017`)

Pull requests into js-ecqm-engine require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
