### PR TITLE
Shift dates

### DIFF
--- a/lib/models/cql_calculator.js
+++ b/lib/models/cql_calculator.js
@@ -52,11 +52,11 @@ module.exports = class CQLCalculator {
     let end;
     // Override default measure_period with effective_date if available
     if (options && options.effective_date != null) {
-      start = this.constructor.getConvertedTime(options.effective_date);
-      if (options.effective_date_end != null) {
-        end = this.constructor.getConvertedTime(options.effective_date_end);
+      end = this.constructor.getConvertedTime(options.effective_date);
+      if (options.measure_period_start != null) {
+        start = this.constructor.getConvertedTime(options.measure_period_start);
       } else {
-        end = this.constructor.getConvertedTimeEndOfYear(options.effective_date);
+        start = this.constructor.getConvertedTimeStartOfYear(options.effective_date);
       }
     } else {
       start = this.constructor.getConvertedTime(measure.get('measure_period').low.value);
@@ -612,11 +612,11 @@ module.exports = class CQLCalculator {
 
   // Converts the given time to the correct format using momentJS
   static getConvertedTime(timeValue) {
-    return moment.utc(timeValue, 'YYYYMDDHHmm').toDate();
+    return moment.utc(timeValue, 'YYYYMDDHHmmss').toDate();
   }
 
-  static getConvertedTimeEndOfYear(timeValue) {
-    return moment.utc(timeValue, 'YYYYMDDHHmm').add(1, 'years').subtract(1, 'seconds').toDate();
+  static getConvertedTimeStartOfYear(timeValue) {
+    return moment.utc(timeValue, 'YYYYMDDHHmmss').subtract(1, 'years').add(1, 'seconds').toDate();
   }
 
   static isValueZero(value, populationSet) {


### PR DESCRIPTION
Changes to how engines handles calc parameters so that it can handle the measure period appropriately according if it differs from defaults.

Pull requests into js-ecqm-engine require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-206
- [x] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name: Neika
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
