### PR TITLE
Pop index

### DIFF
--- a/lib/models/cql_calculator.js
+++ b/lib/models/cql_calculator.js
@@ -132,7 +132,6 @@ module.exports = class CQLCalculator {
     // TODO: Aggregate result should be an AggregateResult object once the model is built,
     //       and should occur in the Handler, not the CQL Calculator
     // let aggregate = CqmModels.IndividualResult();
-
     Object.keys(resultsRaw.patientResults).forEach((patientId) => {
       const result = CqmModels.IndividualResult();
 
@@ -197,19 +196,11 @@ module.exports = class CQLCalculator {
     let populationResults = {};
     let episodeResults = null;
     let population;
-    // Get population
-    if (measure.get('population_ids').stratification) {
-      population = _.find(
-        measure.get('populations'),
-        ['stratification', measure.get('population_ids').stratification]
-      );
-    } else {
-      population = _.find(
-        measure.get('populations'),
-        p => !p.stratification
-      );
+    var popIndex = 0
+    if (measure.get('sub_id')) {
+      popIndex = measure.get('sub_id').charCodeAt(0) - 97
     }
-
+    population = measure.get('populations')[popIndex]
     // patient based measure
     if (!measure.get('episode_of_care')) {
       populationResults =
@@ -318,6 +309,9 @@ module.exports = class CQLCalculator {
       }
       if ('NUMEX' in populationResults) {
         populationResultsHandled.NUMEX = 0;
+      }
+      if ('DENEXCEP' in populationResults) {
+        populationResultsHandled.DENEXCEP = 0;
       }
     // TODO: Temporarily disable the removal of OBSERVs when a member of MSRPOPLEX as to not change actual result values uncomment for 2.1 release
     // else if (populationResults["MSRPOPLEX"]? && !@isValueZero('MSRPOPLEX', populationResults))
@@ -540,10 +534,15 @@ module.exports = class CQLCalculator {
   }
 
   static getPopIndexFromPopName(measure, population, popName) {
-    if (population.stratification) {
-      return popName === 'STRAT' ? population.stratification_index : population.population_index;
+    if (population[popName] != null) {
+      const pop_array = population[popName].split('_')
+      if (pop_array.length > 1) {
+        return pop_array[1]
+      } else {
+        return 0
+      }
     }
-    return _.findIndex(measure.get('populations'), p => p === population);
+    return 0
   }
 
   // Format ValueSets for use by CQL4Browsers

--- a/lib/models/cql_calculator.js
+++ b/lib/models/cql_calculator.js
@@ -128,7 +128,6 @@ module.exports = class CQLCalculator {
           elm, patientSource, measureValueSets,
           measure.get('main_cql_library'), mainLibraryVersion, params,
         );
-
     // TODO: Aggregate result should be an AggregateResult object once the model is built,
     //       and should occur in the Handler, not the CQL Calculator
     // let aggregate = CqmModels.IndividualResult();
@@ -195,12 +194,11 @@ module.exports = class CQLCalculator {
   createPopulationValues(measure, results, patientId, observationDefs) {
     let populationResults = {};
     let episodeResults = null;
-    let population;
-    var popIndex = 0
+    let popIndex = 0;
     if (measure.get('sub_id')) {
-      popIndex = measure.get('sub_id').charCodeAt(0) - 97
+      popIndex = measure.get('sub_id').charCodeAt(0) - 97;
     }
-    population = measure.get('populations')[popIndex]
+    const population = measure.get('populations')[popIndex];
     // patient based measure
     if (!measure.get('episode_of_care')) {
       populationResults =
@@ -535,14 +533,12 @@ module.exports = class CQLCalculator {
 
   static getPopIndexFromPopName(measure, population, popName) {
     if (population[popName] != null) {
-      const pop_array = population[popName].split('_')
-      if (pop_array.length > 1) {
-        return pop_array[1]
-      } else {
-        return 0
+      const popArray = population[popName].split('_');
+      if (popArray.length > 1) {
+        return popArray[1];
       }
     }
-    return 0
+    return 0;
   }
 
   // Format ValueSets for use by CQL4Browsers


### PR DESCRIPTION
This code updates the way in which the population name is determined.  The "population hash" is determined by the measures sub_id.  none = 0, a = 1, b = 2, etc.  within the population hash, the population key is used to find the population index, none = 0, _1 =2, _2 = 3 etc.  This is used to find the population name.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
