### PR TITLE
udpate package.json to reference cqm-models 0.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "amqplib": "^0.5.2",
     "convict": "^4.3.1",
-    "cqm-models": "^0.8.2",
+    "cqm-models": "^0.8.4",
     "lodash": "^4.17.5",
     "moment": "^2.21.0",
     "mongoose": "^5.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,18 +238,18 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cql-execution@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/cql-execution/-/cql-execution-1.2.2.tgz#2d8933e96edc2c0ff04992444fc8d79e3cb556bb"
+cql-execution@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/cql-execution/-/cql-execution-1.2.3.tgz#2c51825da605148f4433f665b3cb6d9fcc9293ee"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"
 
-cqm-models@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/cqm-models/-/cqm-models-0.8.2.tgz#433027e0ee921b981d4cf14d3fa7f960ca68e947"
+cqm-models@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/cqm-models/-/cqm-models-0.8.4.tgz#bc7904939b4867b16108d5c408dde159b03212f5"
   dependencies:
-    cql-execution "1.2.2"
+    cql-execution "1.2.3"
     mongoose "^5.0.7"
 
 cross-spawn@^5.1.0:


### PR DESCRIPTION
Pull requests into js-ecqm-engine require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
